### PR TITLE
error has been fix

### DIFF
--- a/lib/database/models/user.model.ts
+++ b/lib/database/models/user.model.ts
@@ -3,7 +3,7 @@ import { Schema, model, models } from "mongoose";
 const UserSchema = new Schema({
   clerkId: { type: String, required: true, unique: true },
   email: { type: String, required: true, unique: true },
-  username: { type: String, required: true, unique: true },
+  username: { type: String, unique: true },
   firstName: { type: String, required: true },
   lastName: { type: String, required: true },
   photo: { type: String, required: true },

--- a/middleware.ts
+++ b/middleware.ts
@@ -6,6 +6,7 @@ export default authMiddleware({
     "/events/clerk",
     "/api/webhook/stripe",
     "/api/uploadthing",
+    "/api/webhook/clerk",
   ],
   ignoredRoutes: ["/events/clerk", "/api/webhook/stripe", "/api/uploadthing"],
 });


### PR DESCRIPTION
## Description
This pull request addresses an issue where the middleware caused inconsistencies regarding the username requirement between the clerk and mongoose schema during signup. While the clerk middleware did not require a username, the mongoose schema did, leading to unpredictable behavior where the username modal would sometimes appear and sometimes not. The root cause of this issue was traced to the database not properly enforcing the username requirement. Merging this pull request is expected to resolve the problem.

## Changes Made
- Added validation to ensure that a username is optional in the mongoose schema during signup.

## Checklist
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Added unit tests (if applicable)

